### PR TITLE
Build maven package for java

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,16 @@ npx projen
 yarn install
 ```
 
-This will generate an entire repository ready to be published, including Github Workflows for publishing NPM and Pypi packages. The only thing which is needed to be set manually are the tokens for these registries:
+This will generate an entire repository ready to be published, including Github Workflows for publishing NPM, Pypi and maven packages. The only thing which is needed to be set manually are the tokens for these registries:
 
 - `NPM_TOKEN`
 - `TWINE_PASSWORD`
 - `TWINE_USERNAME`
+- `MAVEN_GPG_PRIVATE_KEY`
+- `MAVEN_GPG_PRIVATE_KEY_PASSPHRASE`
+- `MAVEN_PASSWORD`
+- `MAVEN_USERNAME`
+- `MAVEN_STAGING_PROFILE_ID`
 
 ### Updating an existing Provider
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,11 @@ export class CdktfProviderProject extends JsiiProject {
         distName: `${namespace}-cdktf-provider-${providerName}`,
         module: `${namespace}_cdktf_provider_${providerName}`,
       },
+      java: {
+        javaPackage: `${namespace}.cdktf.provider.${providerName}`,
+        mavenGroupId: `${namespace}`,
+        mavenArtifactId: `cdktf-provider-${providerName}`,
+      },
     });
 
     new CdktfConfig(this, { terraformProvider, providerName, providerVersion })

--- a/src/readme.ts
+++ b/src/readme.ts
@@ -27,6 +27,7 @@ Current build targets are:
 
 - npm
 - Pypi
+- maven
 
 ## Versioning
 


### PR DESCRIPTION
I've had some issues getting the aws provider to build with default maven settings, so we may need to tweak them either via `MAVEN_OPTS` environment variable or `.mvn/jvm.config` file.