### PR TITLE
fix: fix package names for Java containing a hyphen

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ const githubNamespace = "hashicorp";
 const getMavenName = (providerName: string): string => {
   return ["null", "random"].includes(providerName)
     ? `${providerName}_provider`
-    : providerName;
+    : providerName.replace(/-/gi, "_");
 };
 export class CdktfProviderProject extends cdk.JsiiProject {
   constructor(options: CdktfProviderProjectOptions) {


### PR DESCRIPTION
replace it with an underscore, as we do when running cdktf get:
https://github.com/hashicorp/terraform-cdk/blob/4645749421c05515012c4891ba985285facc5603/packages/@cdktf/provider-generator/lib/get/constructs-maker.ts#L150
Resolves build failing in https://github.com/hashicorp/cdktf-provider-googlebeta/pull/2