### PR TITLE
feat: ensure we have a 1.x version in every provider

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -137,6 +137,7 @@ export class CdktfProviderProject extends cdk.JsiiProject {
         name: "team-tf-cdk",
         email: "github-team-tf-cdk@hashicorp.com",
       },
+      // sets major version to 1 for the first version but resets it for future versions to allow them to automatically increase to e.g. v2 if breaking changes occurred
       majorVersion: getMajorVersion(options.outdir),
     });
 

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -1120,6 +1120,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
       "release": Object {
         "description": "Prepare a release from \\"main\\" branch",
         "env": Object {
+          "MAJOR": "1",
           "RELEASE": "true",
         },
         "name": "release",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,8 +1,8 @@
-import { CdktfProviderProject, CdktfProviderProjectOptions } from "../src";
-import { synthSnapshot } from "./utils";
-import * as fs from "fs-extra";
 import { execSync } from "child_process";
 import * as path from "path";
+import * as fs from "fs-extra";
+import { CdktfProviderProject, CdktfProviderProjectOptions } from "../src";
+import { synthSnapshot } from "./utils";
 
 const getProject = (
   opts: Partial<CdktfProviderProjectOptions> = {}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,8 @@
 import { CdktfProviderProject, CdktfProviderProjectOptions } from "../src";
 import { synthSnapshot } from "./utils";
+import * as fs from "fs-extra";
+import { execSync } from "child_process";
+import * as path from "path";
 
 const getProject = (
   opts: Partial<CdktfProviderProjectOptions> = {}
@@ -35,4 +38,56 @@ test("build runs without crash reporting", () => {
   const snapshot = synthSnapshot(getProject());
 
   expect(snapshot["cdktf.json"]).toHaveProperty("sendCrashReports", false);
+});
+
+describe("versioning", () => {
+  let tmpDir: string;
+  const ENV_PROJEN_DISABLE_POST = process.env.PROJEN_DISABLE_POST;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync("cdktf-provider-project-");
+    process.env.PROJEN_DISABLE_POST = "1";
+  });
+
+  it("deploys 1.0 as a first version", () => {
+    const outdir = path.resolve(__dirname, "..", tmpDir);
+    const project = getProject({
+      outdir,
+    });
+    project.synth();
+
+    let tasksJson;
+    // Sets major version to 1.0 if no release has been made
+    tasksJson = JSON.parse(
+      fs.readFileSync(`${tmpDir}/.projen/tasks.json`, "utf8")
+    );
+    expect(tasksJson.tasks.release.env.MAJOR).toBe("1");
+
+    // After a release a tag would be created, we simulate this here by manually setting a git tag to 1.0.0
+    execSync(`git init`, { cwd: tmpDir });
+    execSync(`git config user.email "you@example.com"`, { cwd: tmpDir });
+    execSync(`git config user.name "Your Name"`, { cwd: tmpDir });
+
+    execSync(`git add --all`, { cwd: tmpDir });
+    execSync(
+      `git -c commit.gpgsign=false commit -m 'feat: first release, great success'`,
+      {
+        cwd: tmpDir,
+      }
+    );
+    execSync(`git tag -a v1.0.0 -m "v1.0.0"`, { cwd: tmpDir });
+
+    // Not sure why but it seems like the project can not be synthed twice from the same test
+    const project2 = getProject({ outdir });
+    project2.synth();
+    tasksJson = JSON.parse(
+      fs.readFileSync(`${tmpDir}/.projen/tasks.json`, "utf8")
+    );
+    // Once this is done we expect the major version not to be forced to 1.0 anymore
+    expect(tasksJson.tasks.release.env.MAJOR).toBe(undefined);
+  });
+
+  afterEach(() => {
+    fs.removeSync(tmpDir);
+    process.env.PROJEN_DISABLE_POST = ENV_PROJEN_DISABLE_POST;
+  });
 });


### PR DESCRIPTION
This leads to breaking changes creating a major version bump, making
it clearer to users that the upgrade might include a breaking change

