### PR TITLE
fix: remove all dashes from go module name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,10 @@ export class CdktfProviderProject extends cdk.JsiiProject {
         mavenEndpoint: "https://hashicorp.oss.sonatype.org",
       },
       publishToGo: {
-        moduleName: `github.com/hashicorp/cdktf-provider-${providerName}-go`,
+        moduleName: `github.com/hashicorp/cdktf-provider-${providerName.replace(
+          /-/g,
+          ""
+        )}-go`,
         gitUserEmail: "github-team-tf-cdk@hashicorp.com",
         gitUserName: "CDK for Terraform Team",
       },


### PR DESCRIPTION
Fixes #