### PR TITLE
feat: introduce useCustomGithubRunner option

### DIFF
--- a/API.md
+++ b/API.md
@@ -2095,6 +2095,16 @@ public readonly jsiiVersion: string;
 
 ---
 
+##### `useCustomGithubRunner`<sup>Optional</sup> <a name="@cdktf/provider-project.CdktfProviderProjectOptions.property.useCustomGithubRunner"></a>
+
+```typescript
+public readonly useCustomGithubRunner: boolean;
+```
+
+- *Type:* `boolean`
+
+---
+
 ## Classes <a name="Classes"></a>
 
 ### CdktfProviderProject <a name="@cdktf/provider-project.CdktfProviderProject"></a>

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { ProviderUpgrade } from "./provider-upgrade";
 const version = require("../version.json").version;
 
 export interface CdktfProviderProjectOptions extends cdk.JsiiProjectOptions {
+  readonly useCustomGithubRunner?: boolean;
   readonly terraformProvider: string;
   readonly cdktfVersion: string;
   readonly constructsVersion: string;


### PR DESCRIPTION
It will allow to switch memory heavy providers to custom Github Action runners with more memory
