### PR TITLE
chore: make release targets more configurable

### DIFF
--- a/API.md
+++ b/API.md
@@ -2106,6 +2106,8 @@ public readonly githubNamespace: string;
 
 - *Type:* `string`
 
+defaults to "hashicorp".
+
 ---
 
 ##### `jsiiVersion`<sup>Optional</sup> <a name="@cdktf/provider-project.CdktfProviderProjectOptions.property.jsiiVersion"></a>
@@ -2135,6 +2137,20 @@ public readonly namespace: string;
 ```
 
 - *Type:* `string`
+
+defaults to "cdktf".
+
+---
+
+##### `nugetOrg`<sup>Optional</sup> <a name="@cdktf/provider-project.CdktfProviderProjectOptions.property.nugetOrg"></a>
+
+```typescript
+public readonly nugetOrg: string;
+```
+
+- *Type:* `string`
+
+defaults to "HashiCorp".
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -2098,10 +2098,40 @@ public readonly forceMajorVersion: number;
 
 ---
 
+##### `githubNamespace`<sup>Optional</sup> <a name="@cdktf/provider-project.CdktfProviderProjectOptions.property.githubNamespace"></a>
+
+```typescript
+public readonly githubNamespace: string;
+```
+
+- *Type:* `string`
+
+---
+
 ##### `jsiiVersion`<sup>Optional</sup> <a name="@cdktf/provider-project.CdktfProviderProjectOptions.property.jsiiVersion"></a>
 
 ```typescript
 public readonly jsiiVersion: string;
+```
+
+- *Type:* `string`
+
+---
+
+##### `mavenEndpoint`<sup>Optional</sup> <a name="@cdktf/provider-project.CdktfProviderProjectOptions.property.mavenEndpoint"></a>
+
+```typescript
+public readonly mavenEndpoint: string;
+```
+
+- *Type:* `string`
+
+---
+
+##### `namespace`<sup>Optional</sup> <a name="@cdktf/provider-project.CdktfProviderProjectOptions.property.namespace"></a>
+
+```typescript
+public readonly namespace: string;
 ```
 
 - *Type:* `string`

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,9 @@ export interface CdktfProviderProjectOptions extends cdk.JsiiProjectOptions {
   readonly jsiiVersion?: string;
   readonly forceMajorVersion?: number;
   readonly namespace?: string;
+  /**
+   * defaults to "hashicorp"
+   */
   readonly githubNamespace?: string;
   readonly mavenEndpoint?: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,9 @@ export interface CdktfProviderProjectOptions extends cdk.JsiiProjectOptions {
   readonly constructsVersion: string;
   readonly jsiiVersion?: string;
   readonly forceMajorVersion?: number;
+  /**
+   * defaults to "cdktf"
+   */
   readonly namespace?: string;
   /**
    * defaults to "hashicorp"

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,13 +18,12 @@ export interface CdktfProviderProjectOptions extends cdk.JsiiProjectOptions {
   readonly constructsVersion: string;
   readonly jsiiVersion?: string;
   readonly forceMajorVersion?: number;
+  readonly namespace?: string;
+  readonly githubNamespace?: string;
+  readonly mavenEndpoint?: string;
 }
 
-const authorName = "HashiCorp";
 const authorAddress = "https://hashicorp.com";
-const namespace = "cdktf";
-const githubNamespace = "hashicorp";
-
 const getMavenName = (providerName: string): string => {
   return ["null", "random"].includes(providerName)
     ? `${providerName}_provider`
@@ -39,6 +38,10 @@ export class CdktfProviderProject extends cdk.JsiiProject {
       constructsVersion,
       minNodeVersion,
       jsiiVersion,
+      authorName = "HashiCorp",
+      namespace = "cdktf",
+      githubNamespace = "hashicorp",
+      mavenEndpoint = "https://hashicorp.oss.sonatype.org",
     } = options;
     const [fqproviderName, providerVersion] = terraformProvider.split("@");
     const providerName = fqproviderName.split("/").pop();
@@ -48,7 +51,7 @@ export class CdktfProviderProject extends cdk.JsiiProject {
       "providerName may not end with '-go' as this can conflict with repos for go packages"
     );
 
-    const nugetName = `HashiCorp.${pascalCase(
+    const nugetName = `${authorName}.${pascalCase(
       namespace
     )}.Providers.${pascalCase(providerName)}`;
     const mavenName = `com.${githubNamespace}.cdktf.providers.${getMavenName(
@@ -76,11 +79,11 @@ export class CdktfProviderProject extends cdk.JsiiProject {
       publishToMaven: {
         javaPackage: mavenName,
         mavenGroupId: `com.${githubNamespace}`,
-        mavenArtifactId: `cdktf-provider-${providerName}`,
-        mavenEndpoint: "https://hashicorp.oss.sonatype.org",
+        mavenArtifactId: `${namespace}-provider-${providerName}`,
+        mavenEndpoint,
       },
       publishToGo: {
-        moduleName: `github.com/hashicorp/cdktf-provider-${providerName.replace(
+        moduleName: `github.com/${githubNamespace}/${namespace}-provider-${providerName.replace(
           /-/g,
           ""
         )}-go`,
@@ -90,7 +93,7 @@ export class CdktfProviderProject extends cdk.JsiiProject {
       },
     };
 
-    const repository = `${githubNamespace}/cdktf-provider-${providerName.replace(
+    const repository = `${githubNamespace}/${namespace}-provider-${providerName.replace(
       /-/g,
       ""
     )}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,10 @@ export interface CdktfProviderProjectOptions extends cdk.JsiiProjectOptions {
    */
   readonly githubNamespace?: string;
   readonly mavenEndpoint?: string;
+  /**
+   * defaults to "HashiCorp"
+   */
+  readonly nugetOrg?: string;
 }
 
 const authorAddress = "https://hashicorp.com";
@@ -48,6 +52,7 @@ export class CdktfProviderProject extends cdk.JsiiProject {
       namespace = "cdktf",
       githubNamespace = "hashicorp",
       mavenEndpoint = "https://hashicorp.oss.sonatype.org",
+      nugetOrg = "HashiCorp",
     } = options;
     const [fqproviderName, providerVersion] = terraformProvider.split("@");
     const providerName = fqproviderName.split("/").pop();
@@ -57,7 +62,7 @@ export class CdktfProviderProject extends cdk.JsiiProject {
       "providerName may not end with '-go' as this can conflict with repos for go packages"
     );
 
-    const nugetName = `${authorName}.${pascalCase(
+    const nugetName = `${nugetOrg}.${pascalCase(
       namespace
     )}.Providers.${pascalCase(providerName)}`;
     const mavenName = `com.${githubNamespace}.cdktf.providers.${getMavenName(


### PR DESCRIPTION
This will enable us to quickly spin up our own pre-built providers for testing purposes
